### PR TITLE
Remove tests

### DIFF
--- a/toofz.NecroDancer.Web.Api.Tests/Controllers/PlayersControllerTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Controllers/PlayersControllerTests.cs
@@ -100,27 +100,6 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 Assert.IsNotNull(contentResult);
                 Assert.IsNotNull(contentResult.Content);
             }
-
-            [TestMethod]
-            public async Task InvalidState_ReturnsBadRequest()
-            {
-                // Arrange
-                var mockRepository = new Mock<LeaderboardsContext>();
-
-                var mockILeaderboardsStoreClient = new Mock<ILeaderboardsStoreClient>();
-
-                var controller = new PlayersController(
-                    mockRepository.Object,
-                    mockILeaderboardsStoreClient.Object,
-                    LeaderboardsResources.ReadLeaderboardHeaders());
-                controller.ModelState.AddModelError("fakeError", "fakeError");
-
-                // Act
-                var actionResult = await controller.PostPlayers(new List<PlayerModel>());
-
-                // Assert
-                Assert.IsInstanceOfType(actionResult, typeof(InvalidModelStateResult));
-            }
         }
     }
 }

--- a/toofz.NecroDancer.Web.Api.Tests/Controllers/ReplaysControllerTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Controllers/ReplaysControllerTests.cs
@@ -62,24 +62,6 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 Assert.IsNotNull(contentResult);
                 Assert.IsNotNull(contentResult.Content);
             }
-
-            [TestMethod]
-            public async Task InvalidState_ReturnsBadRequest()
-            {
-                // Arrange
-                var mockRepository = new Mock<LeaderboardsContext>();
-
-                var mockILeaderboardsStoreClient = new Mock<ILeaderboardsStoreClient>();
-
-                var controller = new ReplaysController(mockRepository.Object, mockILeaderboardsStoreClient.Object);
-                controller.ModelState.AddModelError("fakeError", "fakeError");
-
-                // Act
-                var actionResult = await controller.PostReplays(new List<ReplayModel>());
-
-                // Assert
-                Assert.IsInstanceOfType(actionResult, typeof(InvalidModelStateResult));
-            }
         }
     }
 }


### PR DESCRIPTION
These tests checked if invalid models would cause an error response. They're no longer neccessary since validation isn't part of the action's responsibility. However, validation logic still needs to be tested.