### PR TITLE
Make additions to API

### DIFF
--- a/toofz.NecroDancer.Web.Api.Tests/Controllers/PlayersControllerTests.cs
+++ b/toofz.NecroDancer.Web.Api.Tests/Controllers/PlayersControllerTests.cs
@@ -321,8 +321,6 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
 
                 // Assert
                 Assert.IsInstanceOfType(result, typeof(OkNegotiatedContentResult<PlayerEntriesDTO>));
-                var contentResult = (OkNegotiatedContentResult<PlayerEntriesDTO>)result;
-                Assert.IsNotNull(contentResult.Content);
             }
         }
 
@@ -419,6 +417,56 @@ namespace toofz.NecroDancer.Web.Api.Tests.Controllers
                 var content = contentResult.Content;
                 Assert.AreEqual(74, content.Version);
                 Assert.AreEqual("BOMB", content.KilledBy);
+            }
+        }
+
+        [TestClass]
+        public class GetPlayerDailyEntriesMethod
+        {
+            [TestMethod]
+            public async Task PlayerNotFound_ReturnsNotFound()
+            {
+                // Arrange
+                var mockPlayers = new MockDbSet<Player>();
+                var players = mockPlayers.Object;
+                var mockDb = new Mock<ILeaderboardsContext>();
+                mockDb.Setup(x => x.Players).Returns(players);
+                var db = mockDb.Object;
+                var storeClient = Mock.Of<ILeaderboardsStoreClient>();
+                var controller = new PlayersController(db, storeClient);
+                var steamId = 1;
+
+                // Act
+                var result = await controller.GetPlayerDailyEntries(steamId);
+
+                // Assert
+                Assert.IsInstanceOfType(result, typeof(NotFoundResult));
+            }
+
+            [TestMethod]
+            public async Task ReturnsPlayerEntries()
+            {
+                // Arrange
+                var steamId = 76561197960481221;
+                var mockPlayers = new MockDbSet<Player>(new Player { SteamId = steamId });
+                var players = mockPlayers.Object;
+                var mockEntries = new MockDbSet<DailyEntry>();
+                var entries = mockEntries.Object;
+                var mockReplays = new MockDbSet<Replay>();
+                var replays = mockReplays.Object;
+                var mockDb = new Mock<ILeaderboardsContext>();
+                mockDb.Setup(x => x.Players).Returns(players);
+                mockDb.Setup(x => x.DailyEntries).Returns(entries);
+                mockDb.Setup(x => x.Replays).Returns(replays);
+                var db = mockDb.Object;
+                var storeClient = Mock.Of<ILeaderboardsStoreClient>();
+                var controller = new PlayersController(db, storeClient);
+
+                // Act
+                var result = await controller.GetPlayerDailyEntries(steamId);
+
+                // Assert
+                Assert.IsInstanceOfType(result, typeof(OkNegotiatedContentResult<PlayerDailyEntriesDTO>));
             }
         }
 

--- a/toofz.NecroDancer.Web.Api.Tests/Resources/GetLeaderboards.json
+++ b/toofz.NecroDancer.Web.Api.Tests/Resources/GetLeaderboards.json
@@ -3,12 +3,13 @@
   "leaderboards": [
     {
       "id": 0,
+      "updated_at": null,
+      "display_name": null,
+      "production": false,
       "product": "amplified",
-      "character": "cadence",
       "mode": "standard",
       "run": "speed",
-      "display_name": null,
-      "updated_at": null,
+      "character": "cadence",
       "total": 0
     }
   ]

--- a/toofz.NecroDancer.Web.Api.Tests/Resources/GetPlayerEntries.json
+++ b/toofz.NecroDancer.Web.Api.Tests/Resources/GetPlayerEntries.json
@@ -1,8 +1,8 @@
 {
   "player": {
     "id": "1",
-    "display_name": "Leonard",
     "updated_at": null,
+    "display_name": "Leonard",
     "avatar": null
   },
   "total": 1,
@@ -10,12 +10,13 @@
     {
       "leaderboard": {
         "id": 739999,
+        "updated_at": null,
+        "display_name": null,
+        "production": false,
         "product": "classic",
-        "character": "cadence",
         "mode": "standard",
         "run": "score",
-        "display_name": null,
-        "updated_at": null,
+        "character": "cadence",
         "total": 0
       },
       "rank": 0,

--- a/toofz.NecroDancer.Web.Api.Tests/Resources/GetPlayerEntry.json
+++ b/toofz.NecroDancer.Web.Api.Tests/Resources/GetPlayerEntry.json
@@ -1,8 +1,8 @@
 {
   "player": {
     "id": "2",
-    "display_name": "Julianna",
     "updated_at": null,
+    "display_name": "Julianna",
     "avatar": null
   },
   "rank": 0,

--- a/toofz.NecroDancer.Web.Api.Tests/Resources/GetPlayers.json
+++ b/toofz.NecroDancer.Web.Api.Tests/Resources/GetPlayers.json
@@ -3,14 +3,14 @@
   "players": [
     {
       "id": "5",
-      "display_name": "Stacey",
       "updated_at": null,
+      "display_name": "Stacey",
       "avatar": null
     },
     {
       "id": "3",
-      "display_name": "Steve",
       "updated_at": null,
+      "display_name": "Steve",
       "avatar": null
     }
   ]

--- a/toofz.NecroDancer.Web.Api/Controllers/LeaderboardsController.cs
+++ b/toofz.NecroDancer.Web.Api/Controllers/LeaderboardsController.cs
@@ -67,12 +67,13 @@ namespace toofz.NecroDancer.Web.Api.Controllers
                         select new LeaderboardDTO
                         {
                             Id = l.LeaderboardId,
+                            UpdatedAt = l.LastUpdate,
+                            DisplayName = l.DisplayName,
+                            IsProduction = l.IsProduction,
                             Product = l.Product.Name,
-                            Character = l.Character.Name,
                             Mode = l.Mode.Name,
                             Run = l.Run.Name,
-                            DisplayName = l.DisplayName,
-                            UpdatedAt = l.LastUpdate,
+                            Character = l.Character.Name,
                             Total = l.Entries.Count,
                         };
 
@@ -110,12 +111,14 @@ namespace toofz.NecroDancer.Web.Api.Controllers
                                      select new LeaderboardDTO
                                      {
                                          Id = l.LeaderboardId,
+                                         UpdatedAt = l.LastUpdate,
+                                         DisplayName = l.DisplayName,
+                                         IsProduction = l.IsProduction,
                                          Product = l.Product.Name,
-                                         Character = l.Character.Name,
                                          Mode = l.Mode.Name,
                                          Run = l.Run.Name,
-                                         DisplayName = l.DisplayName,
-                                         UpdatedAt = l.LastUpdate,
+                                         Character = l.Character.Name,
+                                         Total = l.Entries.Count,
                                      })
                                      .FirstOrDefaultAsync(cancellationToken);
             if (leaderboard == null)
@@ -131,8 +134,8 @@ namespace toofz.NecroDancer.Web.Api.Controllers
                             Player = new
                             {
                                 e.Player.SteamId,
-                                e.Player.Name,
                                 e.Player.LastUpdate,
+                                e.Player.Name,
                                 e.Player.Avatar,
                             },
                             Rank = e.Rank,
@@ -169,8 +172,8 @@ namespace toofz.NecroDancer.Web.Api.Controllers
                                Player = new PlayerDTO
                                {
                                    Id = e.Player.SteamId.ToString(),
-                                   DisplayName = e.Player.Name,
                                    UpdatedAt = e.Player.LastUpdate,
+                                   DisplayName = e.Player.Name,
                                    Avatar = e.Player.Avatar,
                                },
                                Rank = e.Rank,
@@ -222,10 +225,12 @@ namespace toofz.NecroDancer.Web.Api.Controllers
                         select new DailyLeaderboardDTO
                         {
                             Id = l.LeaderboardId,
-                            Date = l.Date,
                             UpdatedAt = l.LastUpdate,
+                            DisplayName = l.DisplayName,
                             IsProduction = l.IsProduction,
                             Product = l.Product.Name,
+                            Date = l.Date,
+                            Total = l.Entries.Count,
                         };
 
             var total = await query.CountAsync(cancellationToken);
@@ -265,10 +270,12 @@ namespace toofz.NecroDancer.Web.Api.Controllers
                                      select new DailyLeaderboardDTO
                                      {
                                          Id = l.LeaderboardId,
-                                         Date = l.Date,
                                          UpdatedAt = l.LastUpdate,
-                                         Product = l.Product.Name,
+                                         DisplayName = l.DisplayName,
                                          IsProduction = l.IsProduction,
+                                         Product = l.Product.Name,
+                                         Date = l.Date,
+                                         Total = l.Entries.Count,
                                      })
                                      .FirstOrDefaultAsync(cancellationToken);
             if (leaderboard == null)
@@ -284,8 +291,8 @@ namespace toofz.NecroDancer.Web.Api.Controllers
                             Player = new
                             {
                                 e.Player.SteamId,
-                                e.Player.Name,
                                 e.Player.LastUpdate,
+                                e.Player.Name,
                                 e.Player.Avatar,
                             },
                             Rank = e.Rank,
@@ -323,8 +330,8 @@ namespace toofz.NecroDancer.Web.Api.Controllers
                                Player = new PlayerDTO
                                {
                                    Id = e.Player.SteamId.ToString(),
-                                   DisplayName = e.Player.Name,
                                    UpdatedAt = e.Player.LastUpdate,
+                                   DisplayName = e.Player.Name,
                                    Avatar = e.Player.Avatar,
                                },
                                Rank = e.Rank,

--- a/toofz.NecroDancer.Web.Api/Models/DailyEntryDTO.cs
+++ b/toofz.NecroDancer.Web.Api/Models/DailyEntryDTO.cs
@@ -2,22 +2,14 @@
 
 namespace toofz.NecroDancer.Web.Api.Models
 {
-    /// <summary>
-    /// A Crypt of the NecroDancer leaderboard entry.
-    /// </summary>
     [DataContract]
-    public sealed class EntryDTO
+    public sealed class DailyEntryDTO
     {
         /// <summary>
         /// The leaderboard that contains the entry.
         /// </summary>
-        [DataMember(Name = "leaderboard", EmitDefaultValue = false)]
-        public LeaderboardDTO Leaderboard { get; set; }
-        /// <summary>
-        /// The player that submitted the entry.
-        /// </summary>
-        [DataMember(Name = "player", EmitDefaultValue = false)]
-        public PlayerDTO Player { get; set; }
+        [DataMember(Name = "leaderboard")]
+        public DailyLeaderboardDTO Leaderboard { get; set; }
         /// <summary>
         /// The rank of the entry on the leaderboard.
         /// </summary>

--- a/toofz.NecroDancer.Web.Api/Models/DailyLeaderboardDTO.cs
+++ b/toofz.NecroDancer.Web.Api/Models/DailyLeaderboardDTO.cs
@@ -15,24 +15,34 @@ namespace toofz.NecroDancer.Web.Api.Models
         [DataMember(Name = "id")]
         public int Id { get; set; }
         /// <summary>
-        /// The date of the daily leaderboard.
-        /// </summary>
-        [DataMember(Name = "date")]
-        public DateTime Date { get; set; }
-        /// <summary>
         /// Time that the leaderboard was last updated at (in UTC)
         /// </summary>
         [DataMember(Name = "updated_at")]
         public DateTime? UpdatedAt { get; set; }
+        /// <summary>
+        /// Display name for the leaderboard.
+        /// </summary>
+        [DataMember(Name = "display_name")]
+        public string DisplayName { get; set; }
+        /// <summary>
+        /// Indicates if the leaderboard is a production leaderboard.
+        /// </summary>
+        [DataMember(Name = "production")]
+        public bool IsProduction { get; set; }
         /// <summary>
         /// Crypt of the NecroDancer product (e.g. classic, amplified)
         /// </summary>
         [DataMember(Name = "product")]
         public string Product { get; set; }
         /// <summary>
-        /// Indicates if the daily leaderboard is a production leaderboard.
+        /// The date of the daily leaderboard.
         /// </summary>
-        [DataMember(Name = "production")]
-        public bool IsProduction { get; set; }
+        [DataMember(Name = "date")]
+        public DateTime Date { get; set; }
+        /// <summary>
+        /// Total number of entries
+        /// </summary>
+        [DataMember(Name = "total")]
+        public int Total { get; set; }
     }
 }

--- a/toofz.NecroDancer.Web.Api/Models/LeaderboardDTO.cs
+++ b/toofz.NecroDancer.Web.Api/Models/LeaderboardDTO.cs
@@ -15,15 +15,25 @@ namespace toofz.NecroDancer.Web.Api.Models
         [DataMember(Name = "id")]
         public int Id { get; set; }
         /// <summary>
+        /// Time that the leaderboard was last updated at (in UTC)
+        /// </summary>
+        [DataMember(Name = "updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+        /// <summary>
+        /// Display name for the leaderboard.
+        /// </summary>
+        [DataMember(Name = "display_name")]
+        public string DisplayName { get; set; }
+        /// <summary>
+        /// Indicates if the leaderboard is a production leaderboard.
+        /// </summary>
+        [DataMember(Name = "production")]
+        public bool IsProduction { get; set; }
+        /// <summary>
         /// Crypt of the NecroDancer product (e.g. classic, amplified)
         /// </summary>
         [DataMember(Name = "product")]
         public string Product { get; set; }
-        /// <summary>
-        /// Crypt of the NecroDancer character (e.g. all-characters, cadence, story-mode)
-        /// </summary>
-        [DataMember(Name = "character")]
-        public string Character { get; set; }
         /// <summary>
         /// Crypt of the NecroDancer mode (e.g. standard, hard, no-return)
         /// </summary>
@@ -35,15 +45,10 @@ namespace toofz.NecroDancer.Web.Api.Models
         [DataMember(Name = "run")]
         public string Run { get; set; }
         /// <summary>
-        /// Display name for the leaderboard.
+        /// Crypt of the NecroDancer character (e.g. all-characters, cadence, story-mode)
         /// </summary>
-        [DataMember(Name = "display_name")]
-        public string DisplayName { get; set; }
-        /// <summary>
-        /// Time that the leaderboard was last updated at (in UTC)
-        /// </summary>
-        [DataMember(Name = "updated_at")]
-        public DateTime? UpdatedAt { get; set; }
+        [DataMember(Name = "character")]
+        public string Character { get; set; }
         /// <summary>
         /// Total number of entries
         /// </summary>

--- a/toofz.NecroDancer.Web.Api/Models/PlayerDTO.cs
+++ b/toofz.NecroDancer.Web.Api/Models/PlayerDTO.cs
@@ -15,15 +15,15 @@ namespace toofz.NecroDancer.Web.Api.Models
         [DataMember(Name = "id")]
         public string Id { get; set; }
         /// <summary>
-        /// The player's display name.
-        /// </summary>
-        [DataMember(Name = "display_name")]
-        public string DisplayName { get; set; }
-        /// <summary>
         /// The time (in UTC) that the player's data was retrieved at.
         /// </summary>
         [DataMember(Name = "updated_at")]
         public DateTime? UpdatedAt { get; set; }
+        /// <summary>
+        /// The player's display name.
+        /// </summary>
+        [DataMember(Name = "display_name")]
+        public string DisplayName { get; set; }
         /// <summary>
         /// The URL of the player's avatar.
         /// </summary>

--- a/toofz.NecroDancer.Web.Api/Models/PlayerDailyEntriesDTO.cs
+++ b/toofz.NecroDancer.Web.Api/Models/PlayerDailyEntriesDTO.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace toofz.NecroDancer.Web.Api.Models
+{
+    [DataContract]
+    public sealed class PlayerDailyEntriesDTO
+    {
+        /// <summary>
+        /// The Steam player.
+        /// </summary>
+        [DataMember(Name = "player")]
+        public PlayerDTO Player { get; set; }
+        /// <summary>
+        /// Total number of leaderboard entries.
+        /// </summary>
+        [DataMember(Name = "total")]
+        public int Total { get; set; }
+        /// <summary>
+        /// A collection of leaderboard entries.
+        /// </summary>
+        [DataMember(Name = "entries")]
+        public IEnumerable<DailyEntryDTO> Entries { get; set; }
+    }
+}

--- a/toofz.NecroDancer.Web.Api/toofz.NecroDancer.Web.Api.csproj
+++ b/toofz.NecroDancer.Web.Api/toofz.NecroDancer.Web.Api.csproj
@@ -356,6 +356,7 @@
     <Compile Include="Models\BulkStoreDTO.cs" />
     <Compile Include="Models\Characters.cs" />
     <Compile Include="Models\CommaSeparatedValues.cs" />
+    <Compile Include="Models\DailyEntryDTO.cs" />
     <Compile Include="Models\DailyLeaderboardDTO.cs" />
     <Compile Include="Models\DailyLeaderboardEntriesDTO.cs" />
     <Compile Include="Models\DailyLeaderboardsEnvelope.cs" />
@@ -375,6 +376,7 @@
     <Compile Include="Models\LeaderboardsEnvelope.cs" />
     <Compile Include="Models\LeaderboardsPagination.cs" />
     <Compile Include="Models\Modes.cs" />
+    <Compile Include="Models\PlayerDailyEntriesDTO.cs" />
     <Compile Include="Models\PlayerDTO.cs" />
     <Compile Include="Models\PlayerEntriesDTO.cs" />
     <Compile Include="Models\PlayerModel.cs" />


### PR DESCRIPTION
* Add endpoint to get a player's daily leaderboard entries.
* Leaderboard responses now include display name, production flag, and entry count if they didn't before.